### PR TITLE
Added index range safety checks

### DIFF
--- a/Assets/Plugins/MeshDebugger/Editor/MeshDebugger.cs
+++ b/Assets/Plugins/MeshDebugger/Editor/MeshDebugger.cs
@@ -351,20 +351,20 @@ public partial class MeshDebugger : EditorWindow, IHasCustomMenu
         {
             case DebugTriangle.Index:
                 EachIndice((i, j, vert) =>
-                    DrawLabel(vert, m_cpu.m_IndiceNormals[i][j], (j + m_cpu.m_IndiceOffsets[i]))
+                    DrawLabel(vert, m_cpu.GetIndexNormalsSafely(i, j), (j + m_cpu.m_IndiceOffsets[i]))
                 );
                 break;
             case DebugTriangle.Area:
                 EachIndice((i, j, vert) =>
                 {
                     var area = m_cpu.m_IndiceAreas[i][j];
-                    DrawLabel(vert, m_cpu.m_IndiceNormals[i][j], area.ToString(area < 1 ? "0.00" : "0.0"));
+                    DrawLabel(vert, m_cpu.GetIndexNormalsSafely(i, j), area.ToString(area < 1 ? "0.00" : "0.0"));
                 }
                 );
                 break;
             case DebugTriangle.Submesh:
                 EachIndice((i, j, vert) =>
-                        DrawLabel(vert, m_cpu.m_IndiceNormals[i][j], i)
+                        DrawLabel(vert, m_cpu.GetIndexNormalsSafely(i, j), i)
                 );
                 break;
         }
@@ -373,12 +373,12 @@ public partial class MeshDebugger : EditorWindow, IHasCustomMenu
         {
             case DebugVertice.Index:
                 EachVert((i, vert) =>
-                    DrawLabel(vert, m_cpu.m_Normals[0][i], i)
+                    DrawLabel(vert, m_cpu.GetNormalSafely(0, i), i)
                 );
                 break;
             case DebugVertice.Shared:
                 EachVert((i, vert) =>
-                    DrawLabel(vert, m_cpu.m_Normals[0][i], m_cpu.m_VertUsedCounts[i])
+                    DrawLabel(vert, m_cpu.GetNormalSafely(0, i), m_cpu.m_VertUsedCounts[i])
                 );
                 break;
             case DebugVertice.Duplicates:

--- a/Assets/Plugins/MeshDebugger/Editor/MeshInfo.cs
+++ b/Assets/Plugins/MeshDebugger/Editor/MeshInfo.cs
@@ -318,6 +318,38 @@ public class MeshInfo
         submesh = 0;
         localidx = src;
     }
+
+    /// <summary>
+    /// If normal data for the specified vertex does not exist then this method will return Vector3.zero
+    /// rather than throwing an IndexOutOfRangeException
+    /// </summary>
+    /// <param name="i1"></param>
+    /// <param name="i2"></param>
+    /// <returns></returns>
+    public Vector3 GetNormalSafely(int i1, int i2)
+    {
+        if (i2 < m_Normals[i1].Count)
+        {
+            return m_Normals[i1][i2];
+        }
+        return Vector3.zero;
+    }
+
+    /// <summary>
+    /// If normal data for the specified index does not exist then this method will return Vector3.zero
+    /// rather than throwing an IndexOutOfRangeException
+    /// </summary>
+    /// <param name="i1"></param>
+    /// <param name="i2"></param>
+    /// <returns></returns>
+    public Vector3 GetIndexNormalsSafely(int i1, int i2)
+    {
+        if (i2 < m_IndiceNormals[i1].Count)
+        {
+            return m_IndiceNormals[i1][i2];
+        }
+        return Vector3.zero;
+    }
 }
 
 internal static class InternalMeshUtil


### PR DESCRIPTION
Meshes with no normal data cause IndexOfOfRangeExceptions. These changes fix that.